### PR TITLE
Fix form constructors and include headers

### DIFF
--- a/ex02/AForm.h
+++ b/ex02/AForm.h
@@ -2,6 +2,7 @@
 #define AFORM_H
 
 #include <iostream>
+#include <string>
 
 class Bureaucrat;
 

--- a/ex02/PresidentialPardonForm.cpp
+++ b/ex02/PresidentialPardonForm.cpp
@@ -2,12 +2,16 @@
 #include "Bureaucrat.h"
 
 PresidentialPardonForm::PresidentialPardonForm()
-    : AForm("PresidentialPardonForm", kDefaultGreadSign, kDefaultGreadExec),
+    : AForm("PresidentialPardonForm", kDefaultGradeSign, kDefaultGradeExec),
       target_("default") {}
+
+PresidentialPardonForm::PresidentialPardonForm(const std::string &target)
+    : AForm("PresidentialPardonForm", kDefaultGradeSign, kDefaultGradeExec),
+      target_(target) {}
 
 PresidentialPardonForm::PresidentialPardonForm(
     const PresidentialPardonForm &form)
-    : AForm(form) {}
+    : AForm(form), target_(form.target_) {}
 
 PresidentialPardonForm &
 PresidentialPardonForm::operator=(const PresidentialPardonForm &form) {

--- a/ex02/PresidentialPardonForm.h
+++ b/ex02/PresidentialPardonForm.h
@@ -6,6 +6,7 @@
 class PresidentialPardonForm : public AForm {
 public:
   PresidentialPardonForm();
+  explicit PresidentialPardonForm(const std::string &target);
   PresidentialPardonForm(const PresidentialPardonForm &form);
   PresidentialPardonForm &operator=(const PresidentialPardonForm &form);
   ~PresidentialPardonForm();
@@ -13,8 +14,8 @@ public:
   void doExecute() const;
 
 private:
-  static const int kDefaultGreadSign = 25;
-  static const int kDefaultGreadExec = 5;
+  static const int kDefaultGradeSign = 25;
+  static const int kDefaultGradeExec = 5;
   const std::string target_;
 };
 #endif

--- a/ex02/RobotomyRequestForm.cpp
+++ b/ex02/RobotomyRequestForm.cpp
@@ -23,6 +23,8 @@ const std::string &RobotomyRequestForm::getTarget() const { return target_; }
 
 void RobotomyRequestForm::doExecute() const {
   std::cout << "~~drilling noises~~" << std::endl;
+  // もし、短時間に連続でこの関数が呼び出された場合、シード値が同じ値で設定されるおそれがある。
+  // シード値を同じ値で設定したすると、乱数に偏りができてしまうため、シード値は呼び出し後1度だけ設定する
   static bool seeded = false;
   if (!seeded) {
     std::srand(std::time(NULL));

--- a/ex02/RobotomyRequestForm.cpp
+++ b/ex02/RobotomyRequestForm.cpp
@@ -2,11 +2,15 @@
 #include "Bureaucrat.h"
 
 RobotomyRequestForm::RobotomyRequestForm()
-    : AForm("RobotomyRequestForm", kDefaultGreadSign, kDefaultGreadExec),
+    : AForm("RobotomyRequestForm", kDefaultGradeSign, kDefaultGradeExec),
       target_("default") {}
 
+RobotomyRequestForm::RobotomyRequestForm(const std::string &target)
+    : AForm("RobotomyRequestForm", kDefaultGradeSign, kDefaultGradeExec),
+      target_(target) {}
+
 RobotomyRequestForm::RobotomyRequestForm(const RobotomyRequestForm &form)
-    : AForm(form) {}
+    : AForm(form), target_(form.target_) {}
 
 RobotomyRequestForm &
 RobotomyRequestForm::operator=(const RobotomyRequestForm &form) {
@@ -19,7 +23,11 @@ const std::string &RobotomyRequestForm::getTarget() const { return target_; }
 
 void RobotomyRequestForm::doExecute() const {
   std::cout << "~~drilling noises~~" << std::endl;
-  std::srand(std::time(NULL));
+  static bool seeded = false;
+  if (!seeded) {
+    std::srand(std::time(NULL));
+    seeded = true;
+  }
   if (std::rand() % 2) {
     std::cout << target_ << " has been robotomized successfully!" << std::endl;
   } else {

--- a/ex02/RobotomyRequestForm.h
+++ b/ex02/RobotomyRequestForm.h
@@ -8,6 +8,7 @@
 class RobotomyRequestForm : public AForm {
 public:
   RobotomyRequestForm();
+  explicit RobotomyRequestForm(const std::string &target);
   RobotomyRequestForm(const RobotomyRequestForm &form);
   RobotomyRequestForm &operator=(const RobotomyRequestForm &form);
   ~RobotomyRequestForm();
@@ -15,8 +16,8 @@ public:
   void doExecute() const;
 
 private:
-  static const int kDefaultGreadSign = 72;
-  static const int kDefaultGreadExec = 45;
+  static const int kDefaultGradeSign = 72;
+  static const int kDefaultGradeExec = 45;
   const std::string target_;
 };
 #endif

--- a/ex02/ShrubberyCreationForm.cpp
+++ b/ex02/ShrubberyCreationForm.cpp
@@ -1,13 +1,18 @@
 #include "ShrubberyCreationForm.h"
 #include "AForm.h"
+#include <stdexcept>
 
 ShrubberyCreationForm::ShrubberyCreationForm()
-    : AForm("ShrubberyCreationForm", kDefaultGreadSign, kDefaultGreadExec),
+    : AForm("ShrubberyCreationForm", kDefaultGradeSign, kDefaultGradeExec),
       target_("default") {}
+
+ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target)
+    : AForm("ShrubberyCreationForm", kDefaultGradeSign, kDefaultGradeExec),
+      target_(target) {}
 
 ShrubberyCreationForm::ShrubberyCreationForm(
     const ShrubberyCreationForm &shrubberycreation)
-    : AForm(shrubberycreation) {}
+    : AForm(shrubberycreation), target_(shrubberycreation.target_) {}
 
 ShrubberyCreationForm &ShrubberyCreationForm::operator=(
     const ShrubberyCreationForm &shrubberycreation) {

--- a/ex02/ShrubberyCreationForm.cpp
+++ b/ex02/ShrubberyCreationForm.cpp
@@ -11,12 +11,12 @@ ShrubberyCreationForm::ShrubberyCreationForm(const std::string &target)
       target_(target) {}
 
 ShrubberyCreationForm::ShrubberyCreationForm(
-    const ShrubberyCreationForm &shrubberycreation)
-    : AForm(shrubberycreation), target_(shrubberycreation.target_) {}
+    const ShrubberyCreationForm &form)
+    : AForm(form) {}
 
 ShrubberyCreationForm &ShrubberyCreationForm::operator=(
-    const ShrubberyCreationForm &shrubberycreation) {
-  AForm::operator=(shrubberycreation);
+    const ShrubberyCreationForm &form) {
+  AForm::operator=(form);
   return *this;
 }
 ShrubberyCreationForm::~ShrubberyCreationForm() {}

--- a/ex02/ShrubberyCreationForm.h
+++ b/ex02/ShrubberyCreationForm.h
@@ -9,9 +9,9 @@ class ShrubberyCreationForm : public AForm {
 public:
   ShrubberyCreationForm();
   explicit ShrubberyCreationForm(const std::string &target);
-  ShrubberyCreationForm(const ShrubberyCreationForm &shrubberycreation);
+  ShrubberyCreationForm(const ShrubberyCreationForm &form);
   ShrubberyCreationForm &
-  operator=(const ShrubberyCreationForm &shrubberycreation);
+  operator=(const ShrubberyCreationForm &form);
   ~ShrubberyCreationForm();
   const std::string &getTarget() const;
   void doExecute() const;

--- a/ex02/ShrubberyCreationForm.h
+++ b/ex02/ShrubberyCreationForm.h
@@ -8,6 +8,7 @@
 class ShrubberyCreationForm : public AForm {
 public:
   ShrubberyCreationForm();
+  explicit ShrubberyCreationForm(const std::string &target);
   ShrubberyCreationForm(const ShrubberyCreationForm &shrubberycreation);
   ShrubberyCreationForm &
   operator=(const ShrubberyCreationForm &shrubberycreation);
@@ -16,8 +17,8 @@ public:
   void doExecute() const;
 
 private:
-  static const int kDefaultGreadSign = 145;
-  static const int kDefaultGreadExec = 137;
+  static const int kDefaultGradeSign = 145;
+  static const int kDefaultGradeExec = 137;
   const std::string target_;
 };
 


### PR DESCRIPTION
## Summary
- add missing `<string>` include to AForm
- add target-aware constructors and correct grade constant names for specific forms
- seed random generator only once in RobotomyRequestForm and include `<stdexcept>` for runtime error

## Testing
- `cd ex02 && make`
- `./Form`


------
https://chatgpt.com/codex/tasks/task_e_68b91027382c8329aaa31faa2afb9843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Create PresidentialPardonForm, RobotomyRequestForm, and ShrubberyCreationForm directly with a target string for quicker setup.
- Bug Fixes
  - Fixed incorrect default grade values and base initialization to ensure correct signing/execution behavior.
  - Copy operations now reliably preserve the form target.
- Performance
  - Robotomy randomness now seeded once per run for steadier behavior and reduced overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->