### PR TITLE
Remove unnecessary Bureaucrat includes

### DIFF
--- a/ex02/RobotomyRequestForm.cpp
+++ b/ex02/RobotomyRequestForm.cpp
@@ -1,5 +1,4 @@
 #include "RobotomyRequestForm.h"
-#include "Bureaucrat.h"
 
 RobotomyRequestForm::RobotomyRequestForm()
     : AForm("RobotomyRequestForm", kDefaultGradeSign, kDefaultGradeExec),

--- a/ex02/ShrubberyCreationForm.h
+++ b/ex02/ShrubberyCreationForm.h
@@ -2,7 +2,6 @@
 #define SHRUBBERYCREATIONFORM_H
 
 #include "AForm.h"
-#include "Bureaucrat.h"
 #include <fstream>
 
 class ShrubberyCreationForm : public AForm {

--- a/ex03/RobotomyRequestForm.cpp
+++ b/ex03/RobotomyRequestForm.cpp
@@ -1,5 +1,4 @@
 #include "RobotomyRequestForm.h"
-#include "Bureaucrat.h"
 
 RobotomyRequestForm::RobotomyRequestForm()
     : AForm("RobotomyRequestForm", kDefaultGradeSign, kDefaultGradeExec),

--- a/ex03/ShrubberyCreationForm.h
+++ b/ex03/ShrubberyCreationForm.h
@@ -2,7 +2,6 @@
 #define SHRUBBERYCREATIONFORM_H
 
 #include "AForm.h"
-#include "Bureaucrat.h"
 #include <fstream>
 
 class ShrubberyCreationForm : public AForm {


### PR DESCRIPTION
## Summary
- Drop unneeded `Bureaucrat.h` include from `ShrubberyCreationForm` headers
- Trim unused `Bureaucrat.h` include in `RobotomyRequestForm` implementations

## Testing
- `make -C ex02`
- `make -C ex03` *(fails: variable `rrf` set but not used)*

------
https://chatgpt.com/codex/tasks/task_e_68b9409ba8588329b28686a2d7e27eb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined internal dependencies across related modules, removing unused references. No changes to functionality, behavior, or public APIs. Slight improvements in compile times and maintainability.
- Chores
  - Performed minor codebase cleanup to simplify module boundaries and reduce unnecessary coupling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->