### PR TITLE
Use C++98-compatible memory handling for Intern forms

### DIFF
--- a/ex03/main.cpp
+++ b/ex03/main.cpp
@@ -10,28 +10,37 @@ int main(void) {
   {
     printSeparator("test shrubbery");
     Intern someRandomIntern;
-    AForm *rrf;
-    rrf = someRandomIntern.makeForm("shrubbery creation", "Bender");
-    std::cout << *rrf << std::endl;
+    AForm* rrf = someRandomIntern.makeForm("shrubbery creation", "Bender");
+    if (rrf) {
+      std::cout << *rrf << std::endl;
+    }
+    delete rrf;
   }
   {
     printSeparator("test robotomy");
     Intern someRandomIntern;
-    AForm *rrf;
-    rrf = someRandomIntern.makeForm("robotomy request", "Bender");
-    std::cout << *rrf << std::endl;
+    AForm* rrf = someRandomIntern.makeForm("robotomy request", "Bender");
+    if (rrf) {
+      std::cout << *rrf << std::endl;
+    }
+    delete rrf;
   }
   {
     printSeparator("test presidential");
     Intern someRandomIntern;
-    AForm *rrf;
-    rrf = someRandomIntern.makeForm("presidential pardon", "Bender");
-    std::cout << *rrf << std::endl;
+    AForm* rrf = someRandomIntern.makeForm("presidential pardon", "Bender");
+    if (rrf) {
+      std::cout << *rrf << std::endl;
+    }
+    delete rrf;
   }
   {
     printSeparator("test invalid name");
     Intern someRandomIntern;
-    AForm *rrf;
-    rrf = someRandomIntern.makeForm("hoge", "Bender");
+    AForm* rrf = someRandomIntern.makeForm("hoge", "Bender");
+    if (rrf) {
+      std::cout << *rrf << std::endl;
+    }
+    delete rrf;
   }
 }


### PR DESCRIPTION
## Summary
- Delete `Intern::makeForm` results manually after null checks
- Compile exercise with `-std=c++98`

## Testing
- `make -C ex00 && ./ex00/Bureaucrat`
- `make -C ex01 && ./ex01/Form`
- `make -C ex02 && ./ex02/Form`
- `make -C ex03 && ./ex03/Form`
- `ASAN_OPTIONS=detect_leaks=1 ./ex03/Form`
- `valgrind --leak-check=full ./ex03/Form` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b94087c910832988a888a8f82711a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes when form creation fails by safely handling null results.
  * Avoids misleading output by only printing details when a form is successfully created.
  * Fixes memory leaks by ensuring created forms are always cleaned up, reducing resource usage over time.
* **Refactor**
  * Streamlined form initialization for clearer, more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->